### PR TITLE
Bugfixes: Add `numpy` in include_dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ build/
 
 *.so
 *.c
+
+my_example/

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ build/
 *.c
 
 my_example/
+dist/
+build/
+*.egg-info/
+my_example/
+*log

--- a/README.md
+++ b/README.md
@@ -34,20 +34,15 @@ Get the filename from a datetime `Ar.fname_from_date(datetime.datetime(2014, 4, 
 
 ![example](examples.png)
 
-
 ### Requirements
 
 [`Anaconda3`](https://www.anaconda.com/distribution/) can make your life easier, especially when you were mad with using different python versions. But it's free of your choice.
 
 ### Installation 
 
-```
-git clone https://github.com/martin-181/ARLreader.git
-cd ARLreader
-python3 example.py
-```
-
 **Installation within a new virtual environment**
+
+create a new virtual environment
 
 ```bash
 conda create -n ARLreader   # you can choose other names as well, 
@@ -58,6 +53,56 @@ conda install python=3.6   # install python, shipped with `pip`, `setuptools`...
 git clone https://github.com/martin-181/ARLreader.git   # download the code repository
 cd ARLreader
 pip install -r requirements.txt   # install the dependencies for ARLreader
+```
+
+compile ARLreader
+
+```bash
+python setup.py install
+```
+
+### Usage
+
+```text
+ARLreader -h   # prompt up the help
+```
+
+Below is the help messages for using `ARLreader`:
+```text
+usage: gdas1_ext [-h] [-s START_TIME] [-e END_TIME] [--latitude LATITUDE]
+                 [--longitude LONGITUDE] [--station STATION]
+                 [-f GLOBAL_FOLDER] [-o PROFILE_FOLDER] [--force]
+
+extract the GDAS1 profile from GDAS1 global binary data.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -s START_TIME, --start_time START_TIME
+                        start time of your interests (yyyymmdd-HHMMSS).
+                        e.g.20151010-120000
+  -e END_TIME, --end_time END_TIME
+                        stop time of your interests (yyyymmdd-HHMMSS).
+                        e.g.20151010-120000
+  --latitude LATITUDE   latitude of your station. (-90, 90).
+                        Default: 30.533721
+  --longitude LONGITUDE
+                        longitude of your station. (0, 360).
+                        Default: 114.367216
+  --station STATION     station name.
+                        Default: wuhan
+  -f GLOBAL_FOLDER, --global_folder GLOBAL_FOLDER
+                        folder for saving the GDAS1 global files.
+                        e.g., 'C:\Users\zhenping\Desktop\global'
+  -o PROFILE_FOLDER, --profile_folder PROFILE_FOLDER
+                        folder for saving the extracted profiles
+                        e.g., 'C:\Users\zhenping\Desktop\wuhan'
+  --force               force to download the GDAS1 global dataset (not suggested)
+```
+
+**setup the reader for a new station**
+
+```
+ARLreader -s 20190920-000000 -e 20190923-000000 --latitude 51.35 --longitude 12.35 --station leipzig -f /Users/zhenping/Data/global -o /Users/zhenping/Data/leipzig
 ```
 
 ### Tests

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ python3 example.py
 **Installation within a new virtual environment**
 
 ```bash
-conda create -n ARLreader   # you can choose other names as well, but using the consistent name during the installation.
+conda create -n ARLreader   # you can choose other names as well, 
+                            # but using the consistent name during the installation.
 activate ARLreader   # activate the virtual environement
 
 conda install python=3.6   # install python, shipped with `pip`, `setuptools`...

--- a/README.md
+++ b/README.md
@@ -35,11 +35,28 @@ Get the filename from a datetime `Ar.fname_from_date(datetime.datetime(2014, 4, 
 ![example](examples.png)
 
 
+### Requirements
+
+[`Anaconda3`](https://www.anaconda.com/distribution/) can make your life easier, especially when you were mad with using different python versions. But it's free of your choice.
+
 ### Installation 
+
 ```
 git clone https://github.com/martin-181/ARLreader.git
 cd ARLreader
 python3 example.py
+```
+
+**Installation within a new virtual environment**
+
+```bash
+conda create -n ARLreader   # you can choose other names as well, but using the consistent name during the installation.
+activate ARLreader   # activate the virtual environement
+
+conda install python=3.6   # install python, shipped with `pip`, `setuptools`...
+git clone https://github.com/martin-181/ARLreader.git   # download the code repository
+cd ARLreader
+pip install -r requirements.txt   # install the dependencies for ARLreader
 ```
 
 ### Tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,23 +1,22 @@
-Package            Version  
------------------- ---------
-atomicwrites       1.3.0    
-attrs              19.1.0   
-certifi            2019.9.11
-colorama           0.4.1    
-Cython             0.29.13  
-importlib-metadata 0.23     
-more-itertools     7.2.0    
-numpy              1.13.3   
-packaging          19.2     
-pip                19.2.3   
-pluggy             0.13.0   
-py                 1.8.0    
-pyparsing          2.4.2    
-pytest             5.1.3    
-setuptools         41.2.0   
-six                1.12.0   
-UNKNOWN            0.0.0    
-wcwidth            0.1.7    
-wheel              0.33.6   
-wincertstore       0.2      
-zipp               0.6.0    
+altgraph==0.16.1
+atomicwrites==1.3.0
+attrs==19.1.0
+certifi==2019.9.11
+colorama==0.4.1
+Cython==0.29.13
+future==0.17.1
+importlib-metadata==0.23
+more-itertools==7.2.0
+numpy==1.13.3
+packaging==19.2
+pefile==2019.4.18
+pluggy==0.13.0
+py==1.8.0
+pyparsing==2.4.2
+pytest==5.1.3
+pywin32-ctypes==0.2.0
+six==1.12.0
+UNKNOWN==0.0.0
+wcwidth==0.1.7
+wincertstore==0.2
+zipp==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,23 @@
-numpy==1.13.3
+Package            Version  
+------------------ ---------
+atomicwrites       1.3.0    
+attrs              19.1.0   
+certifi            2019.9.11
+colorama           0.4.1    
+Cython             0.29.13  
+importlib-metadata 0.23     
+more-itertools     7.2.0    
+numpy              1.13.3   
+packaging          19.2     
+pip                19.2.3   
+pluggy             0.13.0   
+py                 1.8.0    
+pyparsing          2.4.2    
+pytest             5.1.3    
+setuptools         41.2.0   
+six                1.12.0   
+UNKNOWN            0.0.0    
+wcwidth            0.1.7    
+wheel              0.33.6   
+wincertstore       0.2      
+zipp               0.6.0    

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,9 @@
 
 from distutils.core import setup
 from Cython.Build import cythonize
+import numpy
 
 setup(
-    ext_modules = cythonize("ARLreader/fast_funcs.pyx")
-    #ext_modules = cythonize("ARLreader/fast_funcs.pyx", compiler_directives={'linetrace': True, 'binding': True})
+    ext_modules=cythonize("ARLreader/fast_funcs.pyx"),
+    include_dirs=[numpy.get_include()]
 )

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,44 @@
 #!/usr/bin/python3
 
-from distutils.core import setup
 from Cython.Build import cythonize
+from setuptools import setup
 import numpy
 
-setup(
-    ext_modules=cythonize("ARLreader/fast_funcs.pyx"),
-    include_dirs=[numpy.get_include()]
-)
+# Read the long description from the readme file
+with open("readme.md", "rb") as f:
+    long_description = f.read().decode("utf-8")
+
+
+# Run setup
+setup(name='ARLreader',
+      packages=['ARLreader', 'tests'],
+      package_data={},
+
+      version='0.1.0',
+      description='Package for downloading and extracting meteorological' +
+                  ' profiles from GDAS1 global dataset through command line.',
+      long_description=long_description,
+      url='https://github.com/martin-rdz/ARLreader',
+      download_url='https://github.com/martin-rdz/ARLreader/archive/master.zip',
+      author='Martin Radenz',
+      license='MIT',
+      include_package_data=False,
+    #   include_dirs=[numpy.get_include()],
+    #   ext_modules = cythonize("ARLreader/fast_funcs.pyx"),
+      zip_safe=False,
+      classifiers=[
+          'Development Status :: 3 - Alpha',
+          'Programming Language :: Python :: 3',
+          'Intended Audience :: Science/Research',
+      ],
+      keywords='GDAS1 ARL Hysplit',
+      install_requires=[
+          'setuptools',
+          # -*- Extra requirements: -*-
+      ],
+      entry_points={
+          'console_scripts': [
+              'arlreader=ARLreader:main',
+          ],
+      },
+      )


### PR DESCRIPTION
During compiling the fast_funcs.c, it throws the error

```text
(GDAS1) C:\Users\zhenping\Documents\Python Scripts\MyLib\ARLreader>python setup.py install
running install
running build
running build_ext
building 'ARLreader.fast_funcs' extension
C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\BIN\x86_amd64\cl.exe /c /nologo /Ox /W3 /GL /DNDEBUG /MD -IC:\Users\zhenping\Software\envs\GDAS1\include -IC:\Users\zhenping\Software\envs\GDAS1\include "-IC:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\INCLUDE" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.10240.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\8.1\include\shared" "-IC:\Program Files (x86)\Windows Kits\8.1\include\um" "-IC:\Program Files (x86)\Windows Kits\8.1\include\winrt" /TcARLreader/fast_funcs.c /Fobuild\temp.win-amd64-3.6\Release\ARLreader/fast_funcs.obj
fast_funcs.c
ARLreader/fast_funcs.c(498): fatal error C1083: Cannot open include file: 'numpy/arrayobject.h': No
such file or directory
 ```

Fixes can be found in the link below:
python - Cython: "fatal error: numpy/arrayobject.h: No such file or directory" - Stack Overflow